### PR TITLE
feat: add healthcheck handler & register it as endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ It should print something like the following. (Note the port number at the end.)
 curl --location --request POST 'http://localhost:8545' --header 'Content-Type: application/json' --data '{"To": "g1juz2yxmdsa6audkp6ep9vfv80c8p5u76e03vvh"}'
 ```
 
+5. To ensure the faucet is listening to requests, you can ping the health endpoint:
+```bash
+curl --location --request GET 'http://localhost:8545/health'
+```
+
 ### As a library
 
 To add `faucet` to your Go project, simply run:

--- a/faucet.go
+++ b/faucet.go
@@ -98,13 +98,13 @@ func NewFaucet(
 		f.mux.Use(middleware)
 	}
 
+	// Register the health check handler
+	f.mux.Get("/health", f.healthcheckHandler)
+
 	// Set up the request handlers
 	for _, handler := range f.handlers {
 		f.mux.Post(handler.Pattern, handler.HandlerFunc)
 	}
-
-	// Register the health check handler
-	f.mux.Get("/health", f.healthcheckHandler)
 
 	return f, nil
 }

--- a/faucet.go
+++ b/faucet.go
@@ -34,6 +34,7 @@ type Faucet struct {
 	middlewares    []Middleware       // request middlewares
 	handlers       []Handler          // request handlers
 	prepareTxMsgFn PrepareTxMessageFn // transaction message creator
+	healthcheck    bool               // enable health check
 
 	maxSendAmount std.Coins // the max send amount per drip
 }
@@ -52,7 +53,8 @@ func NewFaucet(
 		logger:         noopLogger,
 		config:         config.DefaultConfig(),
 		prepareTxMsgFn: defaultPrepareTxMessage,
-		middlewares:    nil, // no middlewares by default
+		middlewares:    nil,  // no middlewares by default
+		healthcheck:    true, // enable health check by default
 
 		mux: chi.NewMux(),
 	}
@@ -104,7 +106,9 @@ func NewFaucet(
 	}
 
 	// Register the health check handler
-	f.mux.Get("/health", f.healthCheckHandler)
+	if f.healthcheck {
+		f.mux.Get("/health", f.healthcheckHandler)
+	}
 
 	return f, nil
 }

--- a/faucet.go
+++ b/faucet.go
@@ -34,7 +34,6 @@ type Faucet struct {
 	middlewares    []Middleware       // request middlewares
 	handlers       []Handler          // request handlers
 	prepareTxMsgFn PrepareTxMessageFn // transaction message creator
-	healthcheck    bool               // enable health check
 
 	maxSendAmount std.Coins // the max send amount per drip
 }
@@ -53,8 +52,7 @@ func NewFaucet(
 		logger:         noopLogger,
 		config:         config.DefaultConfig(),
 		prepareTxMsgFn: defaultPrepareTxMessage,
-		middlewares:    nil,  // no middlewares by default
-		healthcheck:    true, // enable health check by default
+		middlewares:    nil, // no middlewares by default
 
 		mux: chi.NewMux(),
 	}
@@ -106,9 +104,7 @@ func NewFaucet(
 	}
 
 	// Register the health check handler
-	if f.healthcheck {
-		f.mux.Get("/health", f.healthcheckHandler)
-	}
+	f.mux.Get("/health", f.healthcheckHandler)
 
 	return f, nil
 }

--- a/faucet.go
+++ b/faucet.go
@@ -104,7 +104,7 @@ func NewFaucet(
 	}
 
 	// Register the health check handler
-	f.mux.Get("/healthcheck", f.healthCheckHandler)
+	f.mux.Get("/health", f.healthCheckHandler)
 
 	return f, nil
 }

--- a/faucet.go
+++ b/faucet.go
@@ -103,6 +103,9 @@ func NewFaucet(
 		f.mux.Post(handler.Pattern, handler.HandlerFunc)
 	}
 
+	// Register the health check handler
+	f.mux.Get("/healthcheck", f.healthCheckHandler)
+
 	return f, nil
 }
 

--- a/faucet_test.go
+++ b/faucet_test.go
@@ -122,9 +122,9 @@ func TestFaucet_NewFaucet(t *testing.T) {
 
 		// Make sure the handler was set
 		routes := f.mux.Routes()
-		require.Len(t, routes, len(handlers)+1) // base "/" handler as well
+		require.Len(t, routes, len(handlers)+2) // base "/" & "/healthcheck" handlers as well
 
-		assert.Equal(t, handlers[0].Pattern, routes[1].Pattern)
+		assert.Equal(t, handlers[0].Pattern, routes[2].Pattern)
 	})
 
 	t.Run("with logger", func(t *testing.T) {

--- a/faucet_test.go
+++ b/faucet_test.go
@@ -122,7 +122,7 @@ func TestFaucet_NewFaucet(t *testing.T) {
 
 		// Make sure the handler was set
 		routes := f.mux.Routes()
-		require.Len(t, routes, len(handlers)+2) // base "/" & "/healthcheck" handlers as well
+		require.Len(t, routes, len(handlers)+2) // base "/" & "/health" handlers as well
 
 		assert.Equal(t, handlers[0].Pattern, routes[2].Pattern)
 	})

--- a/faucet_test.go
+++ b/faucet_test.go
@@ -141,43 +141,6 @@ func TestFaucet_NewFaucet(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("without healthcheck", func(t *testing.T) {
-		t.Parallel()
-
-		f, err := NewFaucet(
-			&mockEstimator{},
-			&mockClient{},
-			WithConfig(config.DefaultConfig()),
-			WithHealthcheck(false),
-		)
-
-		require.NotNil(t, f)
-		assert.NoError(t, err)
-
-		// Make sure the healthcheck handler was not set
-		routes := f.mux.Routes()
-		assert.Len(t, routes, 1) // base "/" handler only
-
-	})
-
-	t.Run("with healthcheck", func(t *testing.T) {
-		t.Parallel()
-
-		f, err := NewFaucet(
-			&mockEstimator{},
-			&mockClient{},
-			WithConfig(config.DefaultConfig()),
-		)
-
-		require.NotNil(t, f)
-		assert.NoError(t, err)
-
-		// Make sure the healthcheck handler was set
-		routes := f.mux.Routes()
-		assert.Len(t, routes, 2) // base "/" & "/healthcheck" handlers
-
-	})
-
 	t.Run("with prepare transaction message callback", func(t *testing.T) {
 		t.Parallel()
 

--- a/faucet_test.go
+++ b/faucet_test.go
@@ -141,6 +141,43 @@ func TestFaucet_NewFaucet(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("without healthcheck", func(t *testing.T) {
+		t.Parallel()
+
+		f, err := NewFaucet(
+			&mockEstimator{},
+			&mockClient{},
+			WithConfig(config.DefaultConfig()),
+			WithHealthcheck(false),
+		)
+
+		require.NotNil(t, f)
+		assert.NoError(t, err)
+
+		// Make sure the healthcheck handler was not set
+		routes := f.mux.Routes()
+		assert.Len(t, routes, 1) // base "/" handler only
+
+	})
+
+	t.Run("with healthcheck", func(t *testing.T) {
+		t.Parallel()
+
+		f, err := NewFaucet(
+			&mockEstimator{},
+			&mockClient{},
+			WithConfig(config.DefaultConfig()),
+		)
+
+		require.NotNil(t, f)
+		assert.NoError(t, err)
+
+		// Make sure the healthcheck handler was set
+		routes := f.mux.Routes()
+		assert.Len(t, routes, 2) // base "/" & "/healthcheck" handlers
+
+	})
+
 	t.Run("with prepare transaction message callback", func(t *testing.T) {
 		t.Parallel()
 

--- a/handler.go
+++ b/handler.go
@@ -202,3 +202,9 @@ func extractSendAmount(request Request) (std.Coins, error) {
 
 	return amount, nil
 }
+
+// healthCheckHandler is the default health check handler for the faucet
+func (f *Faucet) healthCheckHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
+}

--- a/handler.go
+++ b/handler.go
@@ -203,8 +203,8 @@ func extractSendAmount(request Request) (std.Coins, error) {
 	return amount, nil
 }
 
-// healthCheckHandler is the default health check handler for the faucet
-func (f *Faucet) healthCheckHandler(w http.ResponseWriter, r *http.Request) {
+// healthcheckHandler is the default health check handler for the faucet
+func (f *Faucet) healthcheckHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("OK"))
 }

--- a/handler.go
+++ b/handler.go
@@ -204,7 +204,6 @@ func extractSendAmount(request Request) (std.Coins, error) {
 }
 
 // healthcheckHandler is the default health check handler for the faucet
-func (f *Faucet) healthcheckHandler(w http.ResponseWriter, r *http.Request) {
+func (f *Faucet) healthcheckHandler(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("OK"))
 }

--- a/options.go
+++ b/options.go
@@ -43,3 +43,10 @@ func WithPrepareTxMessageFn(prepareTxMsgFn PrepareTxMessageFn) Option {
 		f.prepareTxMsgFn = prepareTxMsgFn
 	}
 }
+
+// WithHealthcheck specifies whether to enable the health check
+func WithHealthcheck(enable bool) Option {
+	return func(f *Faucet) {
+		f.healthcheck = enable
+	}
+}

--- a/options.go
+++ b/options.go
@@ -43,10 +43,3 @@ func WithPrepareTxMessageFn(prepareTxMsgFn PrepareTxMessageFn) Option {
 		f.prepareTxMsgFn = prepareTxMsgFn
 	}
 }
-
-// WithHealthcheck specifies whether to enable the health check
-func WithHealthcheck(enable bool) Option {
-	return func(f *Faucet) {
-		f.healthcheck = enable
-	}
-}


### PR DESCRIPTION
close https://github.com/gnolang/gno/issues/2650

I've taken the initiative of integrating the addition of the healthcheck feature directly into the faucet pkg, with an option to enable/disable it (enabled by default), because I think it can avoid having to develop this common feature on several projects. 

Also, the faucet currently creates a new HTTP router, so to add it externally you'd have to export the router or add an option to set the faucet router when it's created (requiring you to modify both the faucet pkg and the overlay in the gno main repository).

The endpoint can be ping like this:

```bash
curl --location --request GET 'http://localhost:8545/health'
```
