### PR TITLE
chore: Remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# CODEOWNERS: https://help.github.com/articles/about-codeowners/
-
-# Primary repo maintainers.
-*                            @gnolang/tech-staff


### PR DESCRIPTION
In gno PR https://github.com/gnolang/gno/pull/3022, we removed CODEOWNERS since we have a different workflow for assigning reviewers. Do the same in this repo. See that PR for the reasoning.